### PR TITLE
move title to navbar, out of hero area

### DIFF
--- a/src/Hero.js
+++ b/src/Hero.js
@@ -4,9 +4,6 @@ class Hero extends React.Component {
 	render() {
 		return (
 			<div className="grid-x align-middle hero__image">
-				<div className="cell medium-6 medium-offset-3 hero__text">
-					<h1 className="hero__headline">Dam Assessment Mapping and Safety System</h1>
-				</div>
 			</div>
 		);
 	}

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -5,7 +5,7 @@ class Navbar extends Component {
         return (
             <div className="top-bar navbar">
                 <div className="top-bar-left">
-                    <h5 className="navbar__site-title"><a href="/index.html">Dam</a></h5>
+                    <h5 className="navbar__site-title"><a href="index.html">Dam Assessment Mapping and Safety System</a></h5>
                 </div>
                 <div className="top-bar-right">
                 </div>


### PR DESCRIPTION
This work was done per @dcgull's request in an email of Sept 29:
"Great, thanks! Can we try one other thing, actually? I wanna put the title up in the header where it just says "Dam" right now. And no text over the hero photo. What do you think of that?"

![screen shot 2018-10-03 at 10 45 57 am](https://user-images.githubusercontent.com/20404311/46428707-8aa49b80-c6f9-11e8-9d87-97af896c9547.png)
