### PR TITLE
layout maps and link to dam build

### DIFF
--- a/src/css/story.css
+++ b/src/css/story.css
@@ -32,3 +32,11 @@
 .story__line-3 .story__img {
     width: 450px;
 }
+
+a.story__report-link {
+    color: #b6b6b6;
+}
+
+a.story__report-link:hover {
+    color: #feb24c;
+}

--- a/src/css/story.css
+++ b/src/css/story.css
@@ -12,6 +12,10 @@
     margin-bottom: 2rem;
 }
 
+.story__line-1 .story__img-container {
+    text-align: center;
+}
+
 .story__line-2 .story__img-container {
     text-align: right;
 }
@@ -20,12 +24,9 @@
     text-align: center;
 }
 
-.story__line-1 .story__img {
-    width: 300px;
-}
-
+.story__line-1 .story__img,
 .story__line-2 .story__img {
-    width: 400px;
+    width: 300px;
 }
 
 .story__line-3 .story__img {

--- a/src/story.js
+++ b/src/story.js
@@ -5,6 +5,8 @@ import barChart from './assets/story-image4.png'
 
 class Story extends Component {
     render() {
+        const damReportLink = "https://water.ca.gov/-/media/DWR-Website/Web-Pages/Programs/All-Programs/Division-of-safety-of-dams/Files/Publications/Dams-Within-Jurisdiction-of-the-State-of-California-2018-Alphabetically-by-Dam-Name.pdf"
+
         return (
             <div className="grid-x story">
                 <div className="cell medium-4 medium-offset-2 story__line story__line-1">
@@ -12,7 +14,7 @@ class Story extends Component {
                     <div className="story__img-container"><img src={ mapImage1 } alt="map showing 1400 dams in California" className="story__img" /></div>
                 </div>
                 <div className="cell medium-4 medium-offset-6 story__line story__line-2">
-                    <p>They are inspected annually by the DWR Division of Safety of Dams. The latest assesment found that 92% are in satisfactory condition. That leaves 98 dams that are not.</p>
+                    <p>They are inspected annually by the DWR Division of Safety of Dams. The <a href={damReportLink} target="_blank" className="story__report-link">latest assessment</a> found that 92% are in satisfactory condition. That leaves 98 dams that are not.</p>
                     <div className="story__img-container"><img src={ mapImage2 } alt="map showing 98 unsatisfactory dams in California" className="story__img" /></div>
                 </div>
                 <div className="cell medium-6 medium-offset-3 story__line story__line-3">


### PR DESCRIPTION
resolves #36 and #39

Map images are now the same size.

The words "latest assessment" in the narrative link to the dam report. I darkened the anchor text slightly to signal that it's a link, and made it the same orange as the map on hover

![screen shot 2018-10-04 at 5 15 46 pm](https://user-images.githubusercontent.com/20404311/46509763-85c71100-c7f9-11e8-80f0-44c39fde3705.png)

![screen shot 2018-10-04 at 5 15 55 pm](https://user-images.githubusercontent.com/20404311/46509778-9d05fe80-c7f9-11e8-9b61-4e1ee60e70c5.png)
